### PR TITLE
Reduce lines required for documentation

### DIFF
--- a/bocker
+++ b/bocker
@@ -85,7 +85,7 @@ case $1 in
 		;;
 	ps) PS ;; #HELP List containers:\n./bocker ps
 	logs) LOGS "$2" ;; #HELP View logs from a container:\n./bocker logs <container_id>
-	commit) COMMIT "$2" "$3" ;;
+	commit) COMMIT "$2" "$3" ;; #HELP Commit a container to the image:\n./bocker commit <container_id> <image_id>
 	rm)	RM "$2" ;; #HELP Delete an image or container:\n./bocker rm <image_id or container_id>
-	*) HELP $0 ;;
+	*) HELP $0 ;; #HELP Display this message:\n./bocker help
 esac

--- a/bocker
+++ b/bocker
@@ -71,21 +71,21 @@ btrfs subvolume snapshot "$btrfs_path/$1" "$btrfs_path/$2" > /dev/null
 echo "Created: $2"
 }
 function HELP() {
-sed -n "s/\\\\n/\n\t/g;s/$/\n/;s/^.*#HELP\\s//p;" < $1
+sed -n "s/\\\\n/\n\t/g;s/BOCKER/${1/\//\\\/}/g;s/$/\n/;s/^.*#HELP\\s//p;" < $1
 exit 0
 }
 [[ -z "${1-}" ]] && HELP $0
 case $1 in
-	init) INIT "$2" ;; #HELP Create an image:\n./bocker init <image_directory>
-	images) IMAGES ;; #HELP List images:\n./bocker images
-	run) #HELP Create a container:\n./bocker run <image_id> <command>
+	init) INIT "$2" ;; #HELP Create an image:\nBOCKER init <image_directory>
+	images) IMAGES ;; #HELP List images:\nBOCKER images
+	run) #HELP Create a container:\nBOCKER run <image_id> <command>
 		IMAGE="$2"
 		shift && shift
 		RUN "$IMAGE" "$*"
 		;;
-	ps) PS ;; #HELP List containers:\n./bocker ps
-	logs) LOGS "$2" ;; #HELP View logs from a container:\n./bocker logs <container_id>
-	commit) COMMIT "$2" "$3" ;; #HELP Commit a container to the image:\n./bocker commit <container_id> <image_id>
-	rm)	RM "$2" ;; #HELP Delete an image or container:\n./bocker rm <image_id or container_id>
-	*) HELP $0 ;; #HELP Display this message:\n./bocker help
+	ps) PS ;; #HELP List containers:\nBOCKER ps
+	logs) LOGS "$2" ;; #HELP View logs from a container:\nBOCKER logs <container_id>
+	commit) COMMIT "$2" "$3" ;; #HELP Commit a container to the image:\nBOCKER commit <container_id> <image_id>
+	rm)	RM "$2" ;; #HELP Delete an image or container:\nBOCKER rm <image_id or container_id>
+	*) HELP $0 ;; #HELP Display this message:\nBOCKER help
 esac

--- a/bocker
+++ b/bocker
@@ -71,7 +71,7 @@ btrfs subvolume snapshot "$btrfs_path/$1" "$btrfs_path/$2" > /dev/null
 echo "Created: $2"
 }
 function HELP() {
-sed -n "s/^.*#HELP\\s//p;" < $1 | sed "s/\\\\n/\n\t/g;s/BOCKER/${1/\//\\\/}/g;s/$/\n/;"
+sed -n "s/^.*#HELP\\s//p;" < $1 | sed "s/\\\\n/\n\t/g;s/$/\n/;s!BOCKER!${1/!/\\!}!g"
 }
 [[ -z "${1-}" ]] && HELP $0 && exit 0
 case $1 in

--- a/bocker
+++ b/bocker
@@ -71,7 +71,7 @@ btrfs subvolume snapshot "$btrfs_path/$1" "$btrfs_path/$2" > /dev/null
 echo "Created: $2"
 }
 function HELP() {
-sed -n "s/\\\\n/\n\t/g;s/BOCKER/${1/\//\\\/}/g;s/$/\n/;s/^.*#HELP\\s//p;" < $1
+sed -n "s/^.*#HELP\\s//p;" < $1 | sed "s/\\\\n/\n\t/g;s/BOCKER/${1/\//\\\/}/g;s/$/\n/;"
 }
 [[ -z "${1-}" ]] && HELP $0 && exit 0
 case $1 in

--- a/bocker
+++ b/bocker
@@ -72,9 +72,8 @@ echo "Created: $2"
 }
 function HELP() {
 sed -n "s/\\\\n/\n\t/g;s/BOCKER/${1/\//\\\/}/g;s/$/\n/;s/^.*#HELP\\s//p;" < $1
-exit 0
 }
-[[ -z "${1-}" ]] && HELP $0
+[[ -z "${1-}" ]] && HELP $0 && exit 0
 case $1 in
 	init) INIT "$2" ;; #HELP Create an image:\nBOCKER init <image_directory>
 	images) IMAGES ;; #HELP List images:\nBOCKER images

--- a/bocker
+++ b/bocker
@@ -71,26 +71,21 @@ btrfs subvolume snapshot "$btrfs_path/$1" "$btrfs_path/$2" > /dev/null
 echo "Created: $2"
 }
 function HELP() {
-echo -e "Create an image: \n\t./bocker init <image_directory>\n"
-echo -e "List images: \n\t./bocker images\n"
-echo -e "Create a container: \n\t./bocker run <image_id> <command>\n"
-echo -e "List containers: \n\t./bocker ps\n"
-echo -e "View logs from a container: \n\t./bocker logs <container_id>\n"
-echo -e "Delete an image or container: \n\t./bocker rm <image_or_container_id>"
+sed -n "s/\\\\n/\n\t/g;s/$/\n/;s/^.*#HELP\\s//p;" < $1
 exit 0
 }
-[[ -z "${1-}" ]] && HELP
+[[ -z "${1-}" ]] && HELP $0
 case $1 in
-	init) INIT "$2" ;;
-	rm)	RM "$2" ;;
-	images) IMAGES ;;
-	ps) PS ;;
-	run)
+	init) INIT "$2" ;; #HELP Create an image:\n./bocker init <image_directory>
+	images) IMAGES ;; #HELP List images:\n./bocker images
+	run) #HELP Create a container:\n./bocker run <image_id> <command>
 		IMAGE="$2"
 		shift && shift
 		RUN "$IMAGE" "$*"
 		;;
-	logs) LOGS "$2" ;;
+	ps) PS ;; #HELP List containers:\n./bocker ps
+	logs) LOGS "$2" ;; #HELP View logs from a container:\n./bocker logs <container_id>
 	commit) COMMIT "$2" "$3" ;;
-	*) HELP ;;
+	rm)	RM "$2" ;; #HELP Delete an image or container:\n./bocker rm <image_id or container_id>
+	*) HELP $0 ;;
 esac


### PR DESCRIPTION
Hey,

GregKH posted this on Google+ and I couldn't help noticing that you could save 6 lines by doing the command documentation in a much more line-efficient manner.

This:
1. Moves the documentation into the case() code as specially formatted comments.
1. Severely reduces the readability of the HELP() function by introducing a nasty sed call, saving 5 lines.
2. Documents the "commit" and "help" commands (Sorry if the commit documentation is crap, I know almost nothing about containers)
3. Saves another line by moving the exit 0 call out of the HELP() function
4. Uses $0 instead of "./bocker" by making the nasty sed call nastier

I'm not overly fussed if you pull or not, but this might give you just enough more lines to implement that next big feature you're thinking about.

Thanks,

Julian Calaby
