### PR TITLE
Shorter case statement

### DIFF
--- a/bocker
+++ b/bocker
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -o errexit -o nounset -o pipefail; shopt -s nullglob
 btrfs_path='/var/bocker';
-function CHECK() {
+function bocker_check() {
 [[ "$1" == 'img' ]] && TYPE='image'
 [[ "$1" == 'ps' ]] && TYPE='container'
 [[ "$1" == '' ]] && TYPE='container or image'
@@ -12,7 +12,7 @@ if [[ "$2" == "$1"* ]]; then
 fi
 echo "No $TYPE named '$2' exists" && exit 1
 }
-function INIT() {
+function bocker_init() {
 if [[ -d "$1" ]]; then
 	uuid="img_$(shuf -i 10000-99999 -n 1)"
 	btrfs subvolume create "$btrfs_path/$uuid" > /dev/null
@@ -22,26 +22,27 @@ else
 	echo "No directory named '$1' exists"
 fi
 }
-function RM() {
-CHECK '' "$1"
+function bocker_rm() {
+bocker_check '' "$1"
 btrfs subvolume delete "$btrfs_path/$1" > /dev/null
 echo "Removed: $1"
 }
-function IMAGES() {
+function bocker_images() {
 echo -e "IMAGE_ID"
 for img in "$btrfs_path"/img_*; do
 	basename "$img"
 done
 }
-function PS() {
+function bocker_ps() {
 echo -e "CONTAINER_ID\t\tCOMMAND"
 for ps in "$btrfs_path"/ps_*; do
 	ps=$(basename "$ps")
 	echo -e "$ps\t\t$(cat "$btrfs_path/$ps/$ps.cmd")"
 done
 }
-function RUN() {
-CHECK 'img' "$1"
+function bocker_run() {
+bocker_check 'img' "$1"
+cmd=${@:2}
 uuid="ps_$(shuf -i 10000-99999 -n 1)"
 ip link add dev veth0_"$uuid" type veth peer name veth1_"$uuid"
 ip link set dev veth0_"$uuid" up
@@ -54,23 +55,23 @@ ip netns exec netns_"$uuid" ip link set dev veth1_"$uuid" up
 ip netns exec netns_"$uuid" ip route add default via 10.0.0.1
 btrfs subvolume snapshot "$btrfs_path/$1" "$btrfs_path/$uuid" > /dev/null
 echo 'nameserver 8.8.8.8' > "$btrfs_path/$uuid"/etc/resolv.conf
-echo "$2" > "$btrfs_path/$uuid/$uuid.cmd"
+echo "$cmd" > "$btrfs_path/$uuid/$uuid.cmd"
 ip netns exec netns_"$uuid" "unshare" -fp --mount-proc "chroot" \
-	"$btrfs_path/$uuid" /bin/sh -c "/bin/mount -t proc proc /proc && $2" \
+	"$btrfs_path/$uuid" /bin/sh -c "/bin/mount -t proc proc /proc && $cmd" \
 	2>&1 | tee "$btrfs_path/$uuid/$uuid.log" || true
 ip link del dev veth0_"$uuid"
 ip netns del netns_"$uuid"
 }
-function LOGS() {
-CHECK 'ps' "$1"
+function bocker_logs() {
+bocker_check 'ps' "$1"
 cat "$btrfs_path/$1/$1.log"
 }
-function COMMIT() {
-CHECK 'ps' "$1" && CHECK 'img' "$2" && RM "$2"
+function bocker_commit() {
+bocker_check 'ps' "$1" && bocker_check 'img' "$2" && bocker_rm "$2"
 btrfs subvolume snapshot "$btrfs_path/$1" "$btrfs_path/$2" > /dev/null
 echo "Created: $2"
 }
-function HELP() {
+function bocker_help() {
 echo -e "Create an image: \n\t./bocker init <image_directory>\n"
 echo -e "List images: \n\t./bocker images\n"
 echo -e "Create a container: \n\t./bocker run <image_id> <command>\n"
@@ -79,18 +80,8 @@ echo -e "View logs from a container: \n\t./bocker logs <container_id>\n"
 echo -e "Delete an image or container: \n\t./bocker rm <image_or_container_id>"
 exit 0
 }
-[[ -z "${1-}" ]] && HELP
+[[ -z "${1-}" ]] && bocker_help
 case $1 in
-	init) INIT "$2" ;;
-	rm)	RM "$2" ;;
-	images) IMAGES ;;
-	ps) PS ;;
-	run)
-		IMAGE="$2"
-		shift && shift
-		RUN "$IMAGE" "$*"
-		;;
-	logs) LOGS "$2" ;;
-	commit) COMMIT "$2" "$3" ;;
-	*) HELP ;;
+	init|rm|images|ps|run|logs|commit) bocker_"$1" "${@:2}" ;;
+	*) bocker_help ;;
 esac


### PR DESCRIPTION
Just for fun: By using `bocker_$1 "${@:2}"`, you can dynamically call different bash functions. This makes the case statement much shorter, saving 9 lines. (Unfortunately, this is incompatible with #1.)

Note: I confess that I barely tested this. Please make sure I didn't break anything (especially run).
