### PR TITLE
cgroup support

### DIFF
--- a/bocker
+++ b/bocker
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -o errexit -o nounset -o pipefail; shopt -s nullglob
-btrfs_path='/var/bocker';
+btrfs_path='/var/bocker'; cgroups='cpu,cpuacct,cpuset,memory'; $(cgget -h &> /dev/null) && CGX="cgexec -g $cgroups" || CGX='_='
 function bocker_check() {
 btrfs subvolume list "$btrfs_path" | grep -qw "$1" && echo 0 || echo 1
 }
@@ -18,6 +18,7 @@ fi
 function bocker_rm() { #HELP Delete an image or container:\nBOCKER rm <image_id or container_id>
 [[ "$(bocker_check "$1")" == 1 ]] && echo "No container named '$1' exists" && exit 1
 btrfs subvolume delete "$btrfs_path/$1" > /dev/null
+cgdelete -g $cgroups:/$1 &> /dev/null || true
 echo "Removed: $1"
 }
 function bocker_images() { #HELP List images:\nBOCKER images
@@ -28,9 +29,8 @@ done
 }
 function bocker_ps() { #HELP List containers:\nBOCKER ps
 echo -e "CONTAINER_ID\t\tCOMMAND"
-for ps in "$btrfs_path"/ps_*; do
-	ps=$(basename "$ps")
-	echo -e "$ps\t\t$(cat "$btrfs_path/$ps/$ps.cmd")"
+for ps in $(ls -dtr "$btrfs_path"/ps_*); do
+	bps=${ps##/*/}; echo -e "$bps\t\t$(cat "$btrfs_path/$bps/$bps.cmd")"
 done
 }
 function bocker_run() { #HELP Create a container:\nBOCKER run <image_id> <command
@@ -51,7 +51,8 @@ ip netns exec netns_"$uuid" ip route add default via 10.0.0.1
 btrfs subvolume snapshot "$btrfs_path/$1" "$btrfs_path/$uuid" > /dev/null
 echo 'nameserver 8.8.8.8' > "$btrfs_path/$uuid"/etc/resolv.conf
 echo "$cmd" > "$btrfs_path/$uuid/$uuid.cmd"
-ip netns exec netns_"$uuid" "unshare" -fp --mount-proc "chroot" \
+cgcreate -g $cgroups:/$uuid && cgset -r cpuset.cpus=0-$(($(grep vendor_id /proc/cpuinfo | wc -l)-1)) $uuid && cgset -r cpuset.mems=0 $uuid &> /dev/null || true
+$CGX:$uuid ip netns exec netns_"$uuid" "unshare" -fp --mount-proc "chroot" \
 	"$btrfs_path/$uuid" /bin/sh -c "/bin/mount -t proc proc /proc && $cmd" \
 	2>&1 | tee "$btrfs_path/$uuid/$uuid.log" || true
 ip link del dev veth0_"$uuid"


### PR DESCRIPTION
A new pull request, to keep features separate.

From my previous request:

cgroups support. Not all of cgroups's toolbox, mind you, but enough to actually run in separate groups, allowing an admin to then fine tune cpu resources, etc. Blame reddit commenters for this!

It should degrade gracefully (no cgroups, no problem) and while I was at it I made a small modification to 'ps' so that it would display the containers based on time of creation rather than name. Feel free to not merge it if it goes against your design.
