### PR TITLE
Renamed cmdline args to BOCKER_ prefix

### DIFF
--- a/bocker
+++ b/bocker
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -o errexit -o nounset -o pipefail; shopt -s nullglob
 btrfs_path='/var/bocker' && cgroups='cpu,cpuacct,memory';
+[[ $# -gt 0 ]] && while [	"${1:0:2}" == '--' ]; do OPTION=${1:2}; [[ $OPTION =~ = ]] && declare "BOCKER_${OPTION/=*/}=${OPTION/*=/}" || declare "BOCKER_${OPTION}=x"; shift; done
 
 function bocker_check() {
 	btrfs subvolume list "$btrfs_path" | grep -qw "$1" && echo 0 || echo 1


### PR DESCRIPTION
I noticed your sadness regarding the lack of command line arguments handling so here is a one liner suggestion :)

Long form only, supports '--a=b' as well as '--a'

Note that 'a' ends up being 'BOCKER_a' to keep in line with your newly added environment variables support so you could type

```
bocker --CPU_SHARE=512 --MEM_LIMIT=512
```
