### PR TITLE
Fix a typo in function bocker_commit

### DIFF
--- a/bocker
+++ b/bocker
@@ -101,7 +101,7 @@ function bocker_logs() { #HELP View logs from a container:\nBOCKER logs <contain
 
 function bocker_commit() { #HELP Commit a container to an image:\nBOCKER commit <container_id> <image_id>
 	[[ "$(bocker_check "$1")" == 1 ]] && echo "No container named '$1' exists" && exit 1
-	[[ "$(bocker_check "$2")" == 1 ]] && echo "No image named '$1' exists" && exit 1
+	[[ "$(bocker_check "$2")" == 1 ]] && echo "No image named '$2' exists" && exit 1
 	bocker_rm "$2" && btrfs subvolume snapshot "$btrfs_path/$1" "$btrfs_path/$2" > /dev/null
 	echo "Created: $2"
 }


### PR DESCRIPTION
In the first two line of bocker_commit(),
the program checks if the arguments are valid,
but the check of image does not return a correct message.
