### PR TITLE
Setup bridge0 and iptables automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Because most distributions do not ship a new enough version of util-linux you wi
 Additionally your system will need to be configured with the following:
 
 * A btrfs filesystem mounted under `/var/bocker`
-* A firewall routing traffic from `bridge0` to a physical interface.
 
 For ease of use a Vagrantfile is included which will build the needed environment.
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Docker implemented in around 100 lines of bash.
 
 The following packages are needed to run bocker.
 
+* [bridge-utils][]
 * btrfs-progs
 * curl
 * iproute2
@@ -24,7 +25,6 @@ Because most distributions do not ship a new enough version of util-linux you wi
 Additionally your system will need to be configured with the following:
 
 * A btrfs filesystem mounted under `/var/bocker`
-* A network bridge called `bridge0` and an IP of 10.0.0.1/24
 * IP forwarding enabled in `/proc/sys/net/ipv4/ip_forward`
 * A firewall routing traffic from `bridge0` to a physical interface.
 
@@ -142,3 +142,5 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+[bridge-utils]: http://sourceforge.net/projects/bridge/

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The following packages are needed to run bocker.
 * iproute2
 * iptables
 * libcgroup-tools
+* [procps][]
 * util-linux >= 2.25.2
 * coreutils >= 7.5
 
@@ -25,7 +26,6 @@ Because most distributions do not ship a new enough version of util-linux you wi
 Additionally your system will need to be configured with the following:
 
 * A btrfs filesystem mounted under `/var/bocker`
-* IP forwarding enabled in `/proc/sys/net/ipv4/ip_forward`
 * A firewall routing traffic from `bridge0` to a physical interface.
 
 For ease of use a Vagrantfile is included which will build the needed environment.
@@ -144,3 +144,4 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 [bridge-utils]: http://sourceforge.net/projects/bridge/
+[procps]: http://procps.sourceforge.net/

--- a/bocker
+++ b/bocker
@@ -63,6 +63,11 @@ function bocker_run() { #HELP Create a container:\nBOCKER run <image_id> <comman
 	[[ "$(bocker_check "$1")" == 1 ]] && echo "No image named '$1' exists" && exit 1
 	[[ "$(bocker_check "$uuid")" == 0 ]] && echo "UUID conflict, retrying..." && bocker_run "$@" && return
 	cmd="${@:2}" && ip="$(echo "${uuid: -3}" | sed 's/0//g')" && mac="${uuid: -3:1}:${uuid: -2}"
+	ip addr list dev bridge0 &> /dev/null || (
+		brctl addbr bridge0
+		ip addr add 10.0.0.1/24 dev bridge0
+		ip link set dev bridge0 up
+	)
 	ip link add dev veth0_"$uuid" type veth peer name veth1_"$uuid"
 	ip link set dev veth0_"$uuid" up
 	ip link set veth0_"$uuid" master bridge0

--- a/bocker
+++ b/bocker
@@ -69,14 +69,12 @@ function bocker_run() { #HELP Create a container:\nBOCKER run <image_id> <comman
 		ip link set dev bridge0 up
 	)
 	ip link add dev veth0_"$uuid" type veth peer name veth1_"$uuid"
-	ip link set dev veth0_"$uuid" up
-	ip link set veth0_"$uuid" master bridge0
+	ip link set dev veth0_"$uuid" up master bridge0
 	ip netns add netns_"$uuid"
 	ip link set veth1_"$uuid" netns netns_"$uuid"
 	ip netns exec netns_"$uuid" ip link set dev lo up
-	ip netns exec netns_"$uuid" ip link set veth1_"$uuid" address 02:42:ac:11:00"$mac"
 	ip netns exec netns_"$uuid" ip addr add 10.0.0."$ip"/24 dev veth1_"$uuid"
-	ip netns exec netns_"$uuid" ip link set dev veth1_"$uuid" up
+	ip netns exec netns_"$uuid" ip link set dev veth1_"$uuid" up address 02:42:ac:11:00"$mac"
 	ip netns exec netns_"$uuid" ip route add default via 10.0.0.1
 	btrfs subvolume snapshot "$btrfs_path/$1" "$btrfs_path/$uuid" > /dev/null
 	echo 'nameserver 8.8.8.8' > "$btrfs_path/$uuid"/etc/resolv.conf

--- a/bocker
+++ b/bocker
@@ -63,6 +63,7 @@ function bocker_run() { #HELP Create a container:\nBOCKER run <image_id> <comman
 	[[ "$(bocker_check "$1")" == 1 ]] && echo "No image named '$1' exists" && exit 1
 	[[ "$(bocker_check "$uuid")" == 0 ]] && echo "UUID conflict, retrying..." && bocker_run "$@" && return
 	cmd="${@:2}" && ip="$(echo "${uuid: -3}" | sed 's/0//g')" && mac="${uuid: -3:1}:${uuid: -2}"
+	sysctl net.ipv4.conf.all.forwarding=1
 	ip addr list dev bridge0 &> /dev/null || (
 		brctl addbr bridge0
 		ip addr add 10.0.0.1/24 dev bridge0

--- a/bocker
+++ b/bocker
@@ -68,6 +68,7 @@ function bocker_run() { #HELP Create a container:\nBOCKER run <image_id> <comman
 		brctl addbr bridge0
 		ip addr add 10.0.0.1/24 dev bridge0
 		ip link set dev bridge0 up
+		iptables -t nat -A POSTROUTING -s 10.0.0.0/24 ! -o bridge0 -j MASQUERADE
 	)
 	ip link add dev veth0_"$uuid" type veth peer name veth1_"$uuid"
 	ip link set dev veth0_"$uuid" up master bridge0


### PR DESCRIPTION
If bridge0 doesn't exist, automatically create it, enable IPv4
forwarding, and setup a minimal MASQUERADE rule so the containers can
access the external network.  Details in the individual commit
messages.

This grows the script by 7 lines (to 124 lines), but allowing most
users to not bother using brctl and iptables is probably worth it ;).
